### PR TITLE
fix: retry without reasoning_effort on Ollama's "does not support thinking" error (#20)

### DIFF
--- a/agent/model.py
+++ b/agent/model.py
@@ -730,8 +730,15 @@ class OpenAICompatibleModel:
         except ModelError as exc:
             text = str(exc).lower()
             unsupported_reasoning = effort and (
-                "reasoning_effort" in text
-                and ("unsupported_parameter" in text or "unknown" in text)
+                (
+                    "reasoning_effort" in text
+                    and ("unsupported_parameter" in text or "unknown" in text)
+                )
+                # Ollama's OpenAI-compat shim rejects reasoning on models that
+                # don't support it (e.g. llama3.2) with a message like
+                # `"llama3.2" does not support thinking`, which never
+                # mentions `reasoning_effort` at all.
+                or ("thinking" in text and "does not support" in text)
             )
             if not unsupported_reasoning:
                 raise

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -114,6 +114,41 @@ class ModelPayloadTests(unittest.TestCase):
             self.assertIn("reasoning_effort", calls[0])
             self.assertNotIn("reasoning_effort", calls[1])
 
+    def test_openai_retries_without_reasoning_for_ollama_thinking_error(self) -> None:
+        """Ollama's OpenAI-compat shim rejects reasoning with a message that
+        never mentions `reasoning_effort`, e.g. for llama3.2 (issue #20)."""
+        calls: list[dict] = []
+
+        def fake_http_json(url, method, headers, payload=None, timeout_sec=90):  # type: ignore[no-untyped-def]
+            calls.append(dict(payload or {}))
+            if len(calls) == 1:
+                raise ModelError(
+                    "HTTP 400 calling http://localhost:11434/v1/chat/completions: "
+                    "{\"error\":{\"message\":\"\\\"llama3.2\\\" does not support "
+                    "thinking\",\"type\":\"api_error\",\"param\":null,\"code\":null}}"
+                )
+            return {
+                "choices": [
+                    {
+                        "message": {"content": "ok", "tool_calls": None},
+                        "finish_reason": "stop",
+                    }
+                ]
+            }
+
+        with patch("agent.model._http_stream_sse", mock_openai_stream(fake_http_json)):
+            model = OpenAICompatibleModel(
+                model="llama3.2",
+                api_key="k",
+                base_url="http://localhost:11434/v1",
+                reasoning_effort="high",
+            )
+            conv = model.create_conversation("system", "user msg")
+            turn = model.complete(conv)
+            self.assertEqual(turn.text, "ok")
+            self.assertIn("reasoning_effort", calls[0])
+            self.assertNotIn("reasoning_effort", calls[1])
+
     def test_anthropic_retries_without_thinking_when_unsupported(self) -> None:
         calls: list[dict] = []
 


### PR DESCRIPTION
## What

Fixes #20 — local Ollama users hit a hard failure when `reasoning_effort` is set
on a model that doesn't support thinking (e.g. `llama3.2`).

## Why

OpenPlanter already recovers when a provider rejects `reasoning_effort`: it
catches the error, drops the parameter, and re-sends once. But that recovery only
fired when the error text contained the substring `reasoning_effort` (OpenAI's
phrasing). Ollama's OpenAI-compat shim rejects reasoning on non-thinking models
with a message like `"llama3.2" does not support thinking`, which never mentions
`reasoning_effort` at all — so the retry never triggered and the request just
failed.

## What changed

- `agent/model.py` — broaden the retry-without-reasoning condition to also match
  `"thinking"` + `"does not support"` errors. The original OpenAI-style clause is
  **preserved** (OR'd on), so providers that already worked behave identically.
  Still effort-gated and single-shot: a genuine, unrelated error still propagates.
- `tests/test_model.py` — regression test using the exact #20 error string,
  asserting the first call sends `reasoning_effort` and the retry drops it.

## Verification

- `python -m pytest tests/test_model.py` — **8/8 pass**.
- revert-confirms-fail: removing the `agent/model.py` change makes the new test
  fail with the uncaught `ModelError`; restored after.
- Verified against a unit mock of Ollama's error shape — there is no live-Ollama
  e2e in the suite, so the fix keys on the documented error string.

## Honest note

This remains string-matching on unstructured provider errors (Ollama sends
`param: null, code: null`, so there's nothing structured to key on) — a future
provider's phrasing could miss again. This PR widens the net for the reported
case; it doesn't replace the approach.

Thanks to the #20 reporter for the exact error string.
