### PR TITLE
build: add Debian .deb and Red Hat .rpm bundle recipes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,5 +73,7 @@ jobs:
             openplanter-desktop/target/${{ matrix.target }}/release/bundle/**/*.dmg
             openplanter-desktop/target/${{ matrix.target }}/release/bundle/**/*.AppImage
             openplanter-desktop/target/${{ matrix.target }}/release/bundle/**/*.msi
+            openplanter-desktop/target/${{ matrix.target }}/release/bundle/**/*.deb
+            openplanter-desktop/target/${{ matrix.target }}/release/bundle/**/*.rpm
           draft: false
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Pre-built binaries are available on the [Releases page](https://github.com/ShinM
 
 - **macOS** — `.dmg`
 - **Windows** — `.msi`
-- **Linux** — `.AppImage`
+- **Linux** — `.AppImage`, `.deb`, `.rpm`
 
 ## Desktop App
 

--- a/openplanter-desktop/crates/op-tauri/tauri.conf.json
+++ b/openplanter-desktop/crates/op-tauri/tauri.conf.json
@@ -24,11 +24,19 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "msi", "appimage"],
+    "targets": ["dmg", "msi", "appimage", "deb", "rpm"],
     "icon": [
       "icons/icon.png",
       "icons/icon.ico"
-    ]
+    ],
+    "linux": {
+      "deb": {
+        "depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"]
+      },
+      "rpm": {
+        "release": "1"
+      }
+    }
   },
   "plugins": {
     "shell": {


### PR DESCRIPTION
## Summary

Adds native Linux package formats to the Tauri desktop release pipeline so Linux users can install OpenPlanter via `.deb` (Debian/Ubuntu) or `.rpm` (Fedora/RHEL/openSUSE) in addition to the existing `.AppImage`.

Changes:
- `openplanter-desktop/crates/op-tauri/tauri.conf.json`: add `deb` and `rpm` to `bundle.targets`, set Debian dependencies (`libwebkit2gtk-4.1-0`, `libgtk-3-0`), and set the RPM release to `1`.
- `.github/workflows/release.yml`: upload `*.deb` and `*.rpm` from the bundle output directory.
- `README.md`: list `.deb` and `.rpm` in the Linux download formats.

The Tauri v2 RPM bundler is pure Rust and does not require `rpmbuild`, so the existing Ubuntu runner can produce both packages. JSON and YAML were validated with Python.

Link to Devin session: https://app.devin.ai/sessions/0ed11202381347e8878eaf7495581b37
Assisted by @devin-ai-integration