### PR TITLE
feat: add OpenFEC API key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,12 @@ openplanter-agent --provider ollama --list-models
 
 The base URL defaults to `http://localhost:11434/v1` and can be overridden with `OPENPLANTER_OLLAMA_BASE_URL` or `--base-url`. The first request may be slow while Ollama loads the model into memory; a 120-second first-byte timeout is used automatically.
 
-Additional service keys: `EXA_API_KEY` (web search), `VOYAGE_API_KEY` (embeddings).
+Additional service keys: `EXA_API_KEY` (web search), `VOYAGE_API_KEY` (embeddings),
+and `FEC_API_KEY` (OpenFEC campaign-finance data; falls back to `DEMO_KEY`).
 
-All keys can also be set with an `OPENPLANTER_` prefix (e.g. `OPENPLANTER_OPENAI_API_KEY`), via `.env` files in the workspace, or via CLI flags.
+Provider and service keys can also be set with an `OPENPLANTER_` prefix (e.g.
+`OPENPLANTER_OPENAI_API_KEY`) or via `.env` files in the workspace. The OpenFEC
+fetcher also accepts an explicit `--api-key`, which overrides the environment.
 
 ## Agent Tools
 

--- a/openplanter-desktop/crates/op-core/src/config.rs
+++ b/openplanter-desktop/crates/op-core/src/config.rs
@@ -66,6 +66,7 @@ pub struct AgentConfig {
     pub cerebras_api_key: Option<String>,
     pub exa_api_key: Option<String>,
     pub voyage_api_key: Option<String>,
+    pub fec_api_key: Option<String>,
 
     // Limits
     pub max_depth: i64,
@@ -109,6 +110,7 @@ impl Default for AgentConfig {
             cerebras_api_key: None,
             exa_api_key: None,
             voyage_api_key: None,
+            fec_api_key: None,
             max_depth: 4,
             max_steps_per_call: 100,
             max_observation_chars: 6000,
@@ -136,23 +138,24 @@ impl AgentConfig {
     pub fn from_env(workspace: impl AsRef<Path>) -> Self {
         let ws = dunce_canonicalize(workspace.as_ref());
 
-        let openai_api_key = env_opt("OPENPLANTER_OPENAI_API_KEY")
-            .or_else(|| env_opt("OPENAI_API_KEY"));
+        let openai_api_key =
+            env_opt("OPENPLANTER_OPENAI_API_KEY").or_else(|| env_opt("OPENAI_API_KEY"));
 
-        let anthropic_api_key = env_opt("OPENPLANTER_ANTHROPIC_API_KEY")
-            .or_else(|| env_opt("ANTHROPIC_API_KEY"));
+        let anthropic_api_key =
+            env_opt("OPENPLANTER_ANTHROPIC_API_KEY").or_else(|| env_opt("ANTHROPIC_API_KEY"));
 
-        let openrouter_api_key = env_opt("OPENPLANTER_OPENROUTER_API_KEY")
-            .or_else(|| env_opt("OPENROUTER_API_KEY"));
+        let openrouter_api_key =
+            env_opt("OPENPLANTER_OPENROUTER_API_KEY").or_else(|| env_opt("OPENROUTER_API_KEY"));
 
-        let cerebras_api_key = env_opt("OPENPLANTER_CEREBRAS_API_KEY")
-            .or_else(|| env_opt("CEREBRAS_API_KEY"));
+        let cerebras_api_key =
+            env_opt("OPENPLANTER_CEREBRAS_API_KEY").or_else(|| env_opt("CEREBRAS_API_KEY"));
 
-        let exa_api_key = env_opt("OPENPLANTER_EXA_API_KEY")
-            .or_else(|| env_opt("EXA_API_KEY"));
+        let exa_api_key = env_opt("OPENPLANTER_EXA_API_KEY").or_else(|| env_opt("EXA_API_KEY"));
 
-        let voyage_api_key = env_opt("OPENPLANTER_VOYAGE_API_KEY")
-            .or_else(|| env_opt("VOYAGE_API_KEY"));
+        let voyage_api_key =
+            env_opt("OPENPLANTER_VOYAGE_API_KEY").or_else(|| env_opt("VOYAGE_API_KEY"));
+
+        let fec_api_key = env_opt("OPENPLANTER_FEC_API_KEY").or_else(|| env_opt("FEC_API_KEY"));
 
         let openai_base_url = env_opt("OPENPLANTER_OPENAI_BASE_URL")
             .or_else(|| env_opt("OPENPLANTER_BASE_URL"))
@@ -167,9 +170,7 @@ impl AgentConfig {
             Some(reasoning_effort_raw)
         };
 
-        let provider_raw = env_or("OPENPLANTER_PROVIDER", "auto")
-            .trim()
-            .to_lowercase();
+        let provider_raw = env_or("OPENPLANTER_PROVIDER", "auto").trim().to_lowercase();
         let provider = if provider_raw.is_empty() {
             "auto".into()
         } else {
@@ -196,10 +197,7 @@ impl AgentConfig {
                 "OPENPLANTER_CEREBRAS_BASE_URL",
                 "https://api.cerebras.ai/v1",
             ),
-            ollama_base_url: env_or(
-                "OPENPLANTER_OLLAMA_BASE_URL",
-                "http://localhost:11434/v1",
-            ),
+            ollama_base_url: env_or("OPENPLANTER_OLLAMA_BASE_URL", "http://localhost:11434/v1"),
             exa_base_url: env_or("OPENPLANTER_EXA_BASE_URL", "https://api.exa.ai"),
             openai_api_key,
             anthropic_api_key,
@@ -207,6 +205,7 @@ impl AgentConfig {
             cerebras_api_key,
             exa_api_key,
             voyage_api_key,
+            fec_api_key,
             max_depth: env_int("OPENPLANTER_MAX_DEPTH", 4),
             max_steps_per_call: env_int("OPENPLANTER_MAX_STEPS", 100),
             max_observation_chars: env_int("OPENPLANTER_MAX_OBS_CHARS", 6000),
@@ -303,10 +302,7 @@ mod tests {
             "OPENPLANTER_DEMO",
         ];
         // Save original values
-        let saved: Vec<_> = keys
-            .iter()
-            .map(|k| (*k, env::var(k).ok()))
-            .collect();
+        let saved: Vec<_> = keys.iter().map(|k| (*k, env::var(k).ok())).collect();
 
         // SAFETY: test-only; combined into one test to avoid parallel env mutation
         unsafe {

--- a/openplanter-desktop/crates/op-core/src/credentials.rs
+++ b/openplanter-desktop/crates/op-core/src/credentials.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// A bundle of API keys for all supported providers.
 ///
-/// Mirrors the Python `CredentialBundle` dataclass.
+/// Credential fields consumed by the desktop application.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CredentialBundle {
     pub openai_api_key: Option<String>,
@@ -18,24 +18,23 @@ pub struct CredentialBundle {
     pub cerebras_api_key: Option<String>,
     pub exa_api_key: Option<String>,
     pub voyage_api_key: Option<String>,
+    pub fec_api_key: Option<String>,
 }
 
 impl CredentialBundle {
     /// Returns `true` if any key has a non-empty value.
     pub fn has_any(&self) -> bool {
-        let keys: [&Option<String>; 6] = [
+        let keys: [&Option<String>; 7] = [
             &self.openai_api_key,
             &self.anthropic_api_key,
             &self.openrouter_api_key,
             &self.cerebras_api_key,
             &self.exa_api_key,
             &self.voyage_api_key,
+            &self.fec_api_key,
         ];
-        keys.iter().any(|k| {
-            k.as_ref()
-                .map(|v| !v.trim().is_empty())
-                .unwrap_or(false)
-        })
+        keys.iter()
+            .any(|k| k.as_ref().map(|v| !v.trim().is_empty()).unwrap_or(false))
     }
 
     /// Fill in missing keys from `other`.
@@ -53,6 +52,7 @@ impl CredentialBundle {
         fill!(cerebras_api_key);
         fill!(exa_api_key);
         fill!(voyage_api_key);
+        fill!(fec_api_key);
     }
 
     /// Serialize to JSON map, omitting `None` values.
@@ -71,6 +71,7 @@ impl CredentialBundle {
         add!(cerebras_api_key, "cerebras_api_key");
         add!(exa_api_key, "exa_api_key");
         add!(voyage_api_key, "voyage_api_key");
+        add!(fec_api_key, "fec_api_key");
         out
     }
 
@@ -89,6 +90,7 @@ impl CredentialBundle {
             cerebras_api_key: get_str(payload, "cerebras_api_key"),
             exa_api_key: get_str(payload, "exa_api_key"),
             voyage_api_key: get_str(payload, "voyage_api_key"),
+            fec_api_key: get_str(payload, "fec_api_key"),
         }
     }
 }
@@ -146,13 +148,10 @@ pub fn parse_env_file(path: &Path) -> CredentialBundle {
             "OPENROUTER_API_KEY",
             "OPENPLANTER_OPENROUTER_API_KEY",
         ),
-        cerebras_api_key: get_key(
-            &env_map,
-            "CEREBRAS_API_KEY",
-            "OPENPLANTER_CEREBRAS_API_KEY",
-        ),
+        cerebras_api_key: get_key(&env_map, "CEREBRAS_API_KEY", "OPENPLANTER_CEREBRAS_API_KEY"),
         exa_api_key: get_key(&env_map, "EXA_API_KEY", "OPENPLANTER_EXA_API_KEY"),
         voyage_api_key: get_key(&env_map, "VOYAGE_API_KEY", "OPENPLANTER_VOYAGE_API_KEY"),
+        fec_api_key: get_key(&env_map, "FEC_API_KEY", "OPENPLANTER_FEC_API_KEY"),
     }
 }
 
@@ -173,6 +172,7 @@ pub fn credentials_from_env() -> CredentialBundle {
         cerebras_api_key: env_key("OPENPLANTER_CEREBRAS_API_KEY", "CEREBRAS_API_KEY"),
         exa_api_key: env_key("OPENPLANTER_EXA_API_KEY", "EXA_API_KEY"),
         voyage_api_key: env_key("OPENPLANTER_VOYAGE_API_KEY", "VOYAGE_API_KEY"),
+        fec_api_key: env_key("OPENPLANTER_FEC_API_KEY", "FEC_API_KEY"),
     }
 }
 
@@ -351,6 +351,7 @@ mod tests {
 OPENAI_API_KEY=sk-from-env
 export ANTHROPIC_API_KEY='ant-key'
 EXA_API_KEY="exa-quoted"
+FEC_API_KEY=fec-from-env
 UNRELATED_VAR=foo
 "#,
         )
@@ -360,6 +361,7 @@ UNRELATED_VAR=foo
         assert_eq!(bundle.openai_api_key, Some("sk-from-env".into()));
         assert_eq!(bundle.anthropic_api_key, Some("ant-key".into()));
         assert_eq!(bundle.exa_api_key, Some("exa-quoted".into()));
+        assert_eq!(bundle.fec_api_key, Some("fec-from-env".into()));
         assert!(bundle.cerebras_api_key.is_none());
     }
 

--- a/openplanter-desktop/crates/op-tauri/src/commands/config.rs
+++ b/openplanter-desktop/crates/op-tauri/src/commands/config.rs
@@ -1,15 +1,13 @@
-use std::collections::HashMap;
-use tauri::State;
 use crate::state::AppState;
+use op_core::credentials::credentials_from_env;
 use op_core::events::{ConfigView, ModelInfo, PartialConfig};
 use op_core::settings::{PersistentSettings, SettingsStore};
-use op_core::credentials::credentials_from_env;
+use std::collections::HashMap;
+use tauri::State;
 
 /// Get the current configuration.
 #[tauri::command]
-pub async fn get_config(
-    state: State<'_, AppState>,
-) -> Result<ConfigView, String> {
+pub async fn get_config(state: State<'_, AppState>) -> Result<ConfigView, String> {
     let cfg = state.config.lock().await;
     let session_id = state.session_id.lock().await;
     Ok(ConfigView {
@@ -142,6 +140,7 @@ pub fn build_credential_status(cfg: &op_core::config::AgentConfig) -> HashMap<St
     status.insert("cerebras".to_string(), cfg.cerebras_api_key.is_some());
     status.insert("ollama".to_string(), true); // Ollama never needs a key
     status.insert("exa".to_string(), cfg.exa_api_key.is_some());
+    status.insert("openfec".to_string(), cfg.fec_api_key.is_some());
     status
 }
 
@@ -174,6 +173,10 @@ pub async fn get_credentials_status(
     status.insert(
         "exa".to_string(),
         cfg.exa_api_key.is_some() || env_creds.exa_api_key.is_some(),
+    );
+    status.insert(
+        "openfec".to_string(),
+        cfg.fec_api_key.is_some() || env_creds.fec_api_key.is_some(),
     );
     Ok(status)
 }
@@ -218,7 +221,10 @@ mod tests {
     #[test]
     fn test_unknown_provider_empty() {
         let models = known_models_for_provider("foo");
-        assert!(models.is_empty(), "unknown provider should return empty vec");
+        assert!(
+            models.is_empty(),
+            "unknown provider should return empty vec"
+        );
     }
 
     #[test]
@@ -226,11 +232,7 @@ mod tests {
         let mut all_ids = HashSet::new();
         for p in &["openai", "anthropic", "openrouter", "cerebras", "ollama"] {
             for m in known_models_for_provider(p) {
-                assert!(
-                    all_ids.insert(m.id.clone()),
-                    "duplicate model ID: {}",
-                    m.id
-                );
+                assert!(all_ids.insert(m.id.clone()), "duplicate model ID: {}", m.id);
             }
         }
     }
@@ -308,6 +310,7 @@ mod tests {
         cfg.openrouter_api_key = Some("k3".to_string());
         cfg.cerebras_api_key = Some("k4".to_string());
         cfg.exa_api_key = Some("k5".to_string());
+        cfg.fec_api_key = Some("k6".to_string());
         let status = build_credential_status(&cfg);
         for (provider, has_key) in &status {
             assert!(has_key, "{} should be true when key is set", provider);
@@ -315,9 +318,23 @@ mod tests {
     }
 
     #[test]
-    fn test_cred_status_has_six_entries() {
+    fn test_cred_status_has_seven_entries() {
         let cfg = op_core::config::AgentConfig::from_env("/nonexistent");
         let status = build_credential_status(&cfg);
-        assert_eq!(status.len(), 6, "should have 6 entries (5 providers + exa)");
+        assert_eq!(
+            status.len(),
+            7,
+            "should have 7 entries (5 providers + exa + openfec)"
+        );
+    }
+
+    #[test]
+    fn test_cred_status_openfec_set() {
+        let mut cfg = op_core::config::AgentConfig::from_env("/nonexistent");
+        cfg.fec_api_key = Some("fec-test".to_string());
+
+        let status = build_credential_status(&cfg);
+
+        assert_eq!(status["openfec"], true);
     }
 }

--- a/openplanter-desktop/crates/op-tauri/src/state.rs
+++ b/openplanter-desktop/crates/op-tauri/src/state.rs
@@ -1,8 +1,10 @@
+use op_core::config::AgentConfig;
+use op_core::credentials::{
+    credentials_from_env, discover_env_candidates, parse_env_file, CredentialBundle,
+};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
-use op_core::config::AgentConfig;
-use op_core::credentials::{credentials_from_env, discover_env_candidates, parse_env_file, CredentialBundle};
 
 /// Merge credentials into an AgentConfig.
 /// Priority: existing config value > env_creds > file_creds.
@@ -14,7 +16,9 @@ pub fn merge_credentials_into_config(
     macro_rules! merge {
         ($field:ident) => {
             if cfg.$field.is_none() {
-                cfg.$field = env_creds.$field.clone()
+                cfg.$field = env_creds
+                    .$field
+                    .clone()
                     .or_else(|| file_creds.$field.clone());
             }
         };
@@ -25,6 +29,7 @@ pub fn merge_credentials_into_config(
     merge!(cerebras_api_key);
     merge!(exa_api_key);
     merge!(voyage_api_key);
+    merge!(fec_api_key);
 }
 
 /// Application state shared across Tauri commands.
@@ -72,6 +77,7 @@ mod tests {
         cfg.cerebras_api_key = None;
         cfg.exa_api_key = None;
         cfg.voyage_api_key = None;
+        cfg.fec_api_key = None;
         cfg
     }
 

--- a/openplanter-desktop/frontend/src/components/App.test.ts
+++ b/openplanter-desktop/frontend/src/components/App.test.ts
@@ -48,7 +48,7 @@ describe("createApp", () => {
     __setHandler("list_sessions", () => [SESSION_B, SESSION_A]);
     __setHandler("get_credentials_status", () => ({
       openai: true, anthropic: true, openrouter: false,
-      cerebras: false, ollama: true, exa: false,
+      cerebras: false, ollama: true, exa: false, openfec: true,
     }));
     __setHandler("open_session", () => ({
       id: "20260227-120000-cccc3333",
@@ -95,9 +95,10 @@ describe("createApp", () => {
 
     await vi.waitFor(() => {
       const creds = root.querySelector(".cred-status");
-      expect(creds!.children.length).toBe(6);
+      expect(creds!.children.length).toBe(7);
       expect(creds!.querySelector(".cred-ok")!.textContent).toContain("openai");
       expect(creds!.querySelector(".cred-missing")!.textContent).toContain("openrouter");
+      expect(creds!.textContent).toContain("openfec");
     });
   });
 

--- a/openplanter-desktop/frontend/src/components/App.ts
+++ b/openplanter-desktop/frontend/src/components/App.ts
@@ -300,7 +300,7 @@ async function loadCredentials(container: HTMLElement): Promise<void> {
   try {
     const status = await getCredentialsStatus();
     container.innerHTML = "";
-    const providers = ["openai", "anthropic", "openrouter", "cerebras", "ollama", "exa"];
+    const providers = ["openai", "anthropic", "openrouter", "cerebras", "ollama", "exa", "openfec"];
     for (const p of providers) {
       const row = document.createElement("div");
       const hasKey = status[p] ?? false;

--- a/scripts/fetch_fec.py
+++ b/scripts/fetch_fec.py
@@ -12,10 +12,12 @@ Uses only Python standard library (urllib, json, csv).
 import argparse
 import csv
 import json
+import os
 import sys
 import urllib.request
 import urllib.parse
 import urllib.error
+from pathlib import Path
 from typing import Dict, List, Any, Optional
 
 
@@ -24,11 +26,55 @@ API_BASE = "https://api.open.fec.gov/v1"
 DEFAULT_API_KEY = "DEMO_KEY"  # Low rate limit; get free key at api.data.gov
 
 
+def redact_api_key(url: str) -> str:
+    """Return a URL safe for diagnostics by removing its OpenFEC credential."""
+    parsed = urllib.parse.urlsplit(url)
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    redacted = [(key, "REDACTED" if key.lower() == "api_key" else value) for key, value in query]
+    return urllib.parse.urlunsplit(parsed._replace(query=urllib.parse.urlencode(redacted)))
+
+
+def resolve_api_key(start: Optional[Path] = None) -> str:
+    """Resolve OpenFEC credentials from the environment or nearest workspace .env."""
+    for name in ("OPENPLANTER_FEC_API_KEY", "FEC_API_KEY"):
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+
+    directory = (start or Path.cwd()).resolve()
+    for parent in (directory, *directory.parents):
+        env_path = parent / ".env"
+        if not env_path.is_file():
+            continue
+        values: Dict[str, str] = {}
+        try:
+            lines = env_path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            break
+        for raw_line in lines:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):].strip()
+            if "=" not in line:
+                continue
+            name, value = line.split("=", 1)
+            values[name.strip()] = value.strip().strip("'\"")
+        for name in ("FEC_API_KEY", "OPENPLANTER_FEC_API_KEY"):
+            value = values.get(name, "").strip()
+            if value:
+                return value
+        break
+
+    return DEFAULT_API_KEY
+
+
 class FECAPIClient:
     """Simple FEC API client using urllib."""
 
-    def __init__(self, api_key: str = DEFAULT_API_KEY):
-        self.api_key = api_key
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or resolve_api_key()
         self.base_url = API_BASE
 
     def _build_url(self, endpoint: str, params: Dict[str, Any]) -> str:
@@ -46,13 +92,13 @@ class FECAPIClient:
                 data = response.read()
                 return json.loads(data.decode('utf-8'))
         except urllib.error.HTTPError as e:
-            print(f"HTTP Error {e.code}: {e.reason}", file=sys.stderr)
-            print(f"URL: {url}", file=sys.stderr)
+            print(f"HTTP Error {e.code}", file=sys.stderr)
+            print(f"URL: {redact_api_key(url)}", file=sys.stderr)
             if e.code == 403:
                 print("Hint: Check your API key or try a different endpoint", file=sys.stderr)
             raise
-        except urllib.error.URLError as e:
-            print(f"URL Error: {e.reason}", file=sys.stderr)
+        except urllib.error.URLError:
+            print("URL Error", file=sys.stderr)
             raise
 
     def get_candidates(
@@ -198,7 +244,7 @@ def fetch_all_pages(
             page += 1
 
         except Exception as e:
-            print(f"Error fetching page {page}: {e}", file=sys.stderr)
+            print(f"Error fetching page {page}: {type(e).__name__}", file=sys.stderr)
             break
 
     return all_results
@@ -273,8 +319,8 @@ Environment:
 
     parser.add_argument(
         '--api-key',
-        default=DEFAULT_API_KEY,
-        help=f'FEC API key (default: {DEFAULT_API_KEY})'
+        default=None,
+        help='FEC API key (overrides FEC_API_KEY; default: DEMO_KEY)'
     )
 
     parser.add_argument(
@@ -408,7 +454,7 @@ Environment:
         print("\nInterrupted by user", file=sys.stderr)
         sys.exit(130)
     except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
+        print(f"Error: {type(e).__name__}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/tests/test_fetch_fec.py
+++ b/tests/test_fetch_fec.py
@@ -10,7 +10,11 @@ import unittest
 import sys
 import os
 import json
+import io
+import tempfile
+from pathlib import Path
 from unittest import skipIf
+from unittest.mock import patch
 
 # Add scripts directory to path to import fetch_fec
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
@@ -39,6 +43,142 @@ class TestFecFetch(unittest.TestCase):
     def setUp(self):
         """Set up test client."""
         self.client = fetch_fec.FECAPIClient(api_key='DEMO_KEY')
+
+    def test_client_uses_fec_api_key_from_environment(self):
+        """FEC_API_KEY is the default credential for API requests."""
+        with patch.dict(os.environ, {"FEC_API_KEY": "env-fec-key"}, clear=False):
+            client = fetch_fec.FECAPIClient()
+
+        self.assertEqual(client.api_key, "env-fec-key")
+
+    def test_explicit_api_key_overrides_environment(self):
+        """An explicit --api-key value takes precedence over FEC_API_KEY."""
+        with patch.dict(os.environ, {"FEC_API_KEY": "env-fec-key"}, clear=False):
+            client = fetch_fec.FECAPIClient(api_key="explicit-fec-key")
+
+        self.assertEqual(client.api_key, "explicit-fec-key")
+
+    def test_openplanter_environment_key_overrides_generic_key(self):
+        """The app-specific process variable wins when both keys are set."""
+        with patch.dict(
+            os.environ,
+            {
+                "FEC_API_KEY": "generic-fec-key",
+                "OPENPLANTER_FEC_API_KEY": "openplanter-fec-key",
+            },
+            clear=False,
+        ):
+            client = fetch_fec.FECAPIClient()
+
+        self.assertEqual(client.api_key, "openplanter-fec-key")
+
+    def test_client_uses_fec_api_key_from_nearest_workspace_env(self):
+        """The nearest workspace .env supplies the default OpenFEC credential."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace = Path(temp_dir)
+            (workspace / ".env").write_text("FEC_API_KEY=workspace-fec-key\n", encoding="utf-8")
+            nested = workspace / "nested"
+            nested.mkdir()
+            with patch.dict(
+                os.environ,
+                {"FEC_API_KEY": "", "OPENPLANTER_FEC_API_KEY": ""},
+                clear=False,
+            ), patch("pathlib.Path.cwd", return_value=nested):
+                client = fetch_fec.FECAPIClient()
+
+        self.assertEqual(client.api_key, "workspace-fec-key")
+
+    def test_http_errors_redact_api_key(self):
+        """Request diagnostics never disclose the OpenFEC credential."""
+        secret = "sensitive-fec-key"
+        client = fetch_fec.FECAPIClient(api_key=secret)
+        url = client._build_url("candidates", {})
+        error = fetch_fec.urllib.error.HTTPError(
+            url,
+            403,
+            f"upstream rejected {url}",
+            {},
+            None,
+        )
+        stderr = io.StringIO()
+
+        with patch("urllib.request.urlopen", side_effect=error), patch("sys.stderr", stderr):
+            with self.assertRaises(fetch_fec.urllib.error.HTTPError):
+                client._request(url)
+
+        output = stderr.getvalue()
+        self.assertNotIn(secret, output)
+        self.assertIn("api_key=REDACTED", output)
+
+    def test_url_errors_do_not_print_api_key_from_reason(self):
+        """URL error reasons are not trusted to be free of credentials."""
+        secret = "sensitive-url-error-key"
+        client = fetch_fec.FECAPIClient(api_key=secret)
+        url = client._build_url("candidates", {})
+        stderr = io.StringIO()
+
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=fetch_fec.urllib.error.URLError(f"cannot fetch {url}"),
+        ), patch("sys.stderr", stderr):
+            with self.assertRaises(fetch_fec.urllib.error.URLError):
+                client._request(url)
+
+        self.assertNotIn(secret, stderr.getvalue())
+
+    def test_pagination_errors_do_not_print_api_key_from_exception(self):
+        """Pagination diagnostics reveal only the exception type."""
+        secret = "sensitive-pagination-key"
+        url = f"{fetch_fec.API_BASE}/candidates/?api_key={secret}"
+        stderr = io.StringIO()
+
+        def failing_endpoint(page):
+            raise RuntimeError(f"cannot fetch {url}")
+
+        with patch("sys.stderr", stderr):
+            result = fetch_fec.fetch_all_pages(
+                fetch_fec.FECAPIClient(api_key=secret),
+                failing_endpoint,
+            )
+
+        self.assertEqual(result, [])
+        self.assertNotIn(secret, stderr.getvalue())
+        self.assertIn("RuntimeError", stderr.getvalue())
+
+    def test_totals_cli_errors_do_not_print_api_key_from_exception(self):
+        """The top-level CLI handler does not reprint credential-bearing errors."""
+        secret = "sensitive-totals-key"
+        stderr = io.StringIO()
+
+        def failing_request(url, timeout):
+            raise fetch_fec.urllib.error.HTTPError(
+                url,
+                403,
+                f"upstream rejected {url}",
+                {},
+                None,
+            )
+
+        argv = [
+            "fetch_fec.py",
+            "--endpoint",
+            "totals",
+            "--candidate",
+            "P80001571",
+            "--api-key",
+            secret,
+        ]
+        with patch.object(sys, "argv", argv), patch(
+            "urllib.request.urlopen",
+            side_effect=failing_request,
+        ), patch("sys.stderr", stderr):
+            with self.assertRaisesRegex(SystemExit, "1"):
+                fetch_fec.main()
+
+        output = stderr.getvalue()
+        self.assertNotIn(secret, output)
+        self.assertIn("api_key=REDACTED", output)
+        self.assertIn("Error: HTTPError", output)
 
     @skipIf(not NETWORK_AVAILABLE, "Network or FEC API unavailable")
     def test_get_candidates_basic(self):


### PR DESCRIPTION
## Summary

- load OpenFEC credentials from the process environment or nearest workspace `.env`
- let the fetcher's explicit `--api-key` override environment configuration
- show OpenFEC configuration status in the desktop Credentials panel
- redact API keys from HTTP, URL, pagination, totals, and top-level error paths

## Why

The existing OpenFEC fetcher accepted an API-key argument but did not consume the documented `FEC_API_KEY` environment variable. This made workspace `.env` configuration ineffective and encouraged passing credentials on the command line. The desktop also had no way to indicate whether OpenFEC was configured.

## User impact

Users can add `FEC_API_KEY` (or `OPENPLANTER_FEC_API_KEY`) to their workspace `.env` and use the OpenFEC fetcher without placing a credential in the command or replay output. The desktop Credentials panel now reports the service as `openfec`.

## Validation

- Rust workspace: 285 tests passed
- Frontend: 200 tests passed
- Frontend production build passed
- Python suite excluding the unrelated Census live-test module: 671 passed, 41 skipped
- OpenFEC regression suite: 18 tests passed, 6 network-dependent tests skipped
- Bundled Tauri application launched and the OpenFEC credential row was exercised
- Diff-level secret scan found no leaks
- Two independent fixed-point reviews completed with no remaining findings
