### PR TITLE
feat(desktop): add Upstage provider + workspace/session fixes

### DIFF
--- a/openplanter-desktop/crates/op-core/src/builder.rs
+++ b/openplanter-desktop/crates/op-core/src/builder.rs
@@ -29,6 +29,9 @@ static OPENAI_RE: LazyLock<Regex> =
 static CEREBRAS_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^(llama.*cerebras|qwen-3|gpt-oss|zai-glm)").unwrap());
 
+static UPSTAGE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^solar").unwrap());
+
 // Ollama regex: `qwen` without lookahead — Cerebras check runs first, so
 // `qwen-3*` is already caught before we reach this regex.
 static OLLAMA_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -48,6 +51,9 @@ pub fn infer_provider_for_model(model: &str) -> Option<&'static str> {
     }
     if CEREBRAS_RE.is_match(model) {
         return Some("cerebras");
+    }
+    if UPSTAGE_RE.is_match(model) {
+        return Some("upstage");
     }
     if OPENAI_RE.is_match(model) {
         return Some("openai");
@@ -117,6 +123,7 @@ pub fn resolve_provider(cfg: &AgentConfig) -> Result<String, ModelError> {
         ("openai", &cfg.openai_api_key),
         ("openrouter", &cfg.openrouter_api_key),
         ("cerebras", &cfg.cerebras_api_key),
+        ("upstage", &cfg.upstage_api_key),
         ("ollama", &None), // ollama is always last — no key needed
     ];
 
@@ -190,6 +197,19 @@ pub fn resolve_endpoint(
                 })?;
             Ok((cfg.cerebras_base_url.clone(), key.to_string()))
         }
+        "upstage" => {
+            let key = cfg
+                .upstage_api_key
+                .as_deref()
+                .or(cfg.api_key.as_deref())
+                .filter(|k| !k.is_empty())
+                .ok_or_else(|| {
+                    ModelError::Message(
+                        "No Upstage API key. Set UPSTAGE_API_KEY or OPENPLANTER_UPSTAGE_API_KEY.".into(),
+                    )
+                })?;
+            Ok((cfg.upstage_base_url.clone(), key.to_string()))
+        }
         "ollama" => {
             // Ollama doesn't need a real key — use a dummy
             Ok((cfg.ollama_base_url.clone(), "ollama".to_string()))
@@ -213,7 +233,7 @@ pub fn build_model(cfg: &AgentConfig) -> Result<Box<dyn BaseModel>, ModelError> 
             cfg.reasoning_effort.clone(),
         ))),
         _ => {
-            // OpenAI-compatible: openai, openrouter, cerebras, ollama
+            // OpenAI-compatible: openai, openrouter, cerebras, upstage, ollama
             let mut extra_headers = HashMap::new();
             if provider == "openrouter" {
                 extra_headers.insert(
@@ -280,6 +300,13 @@ mod tests {
             infer_provider_for_model("qwen-3-235b-a22b-instruct-2507"),
             Some("cerebras")
         );
+    }
+
+    #[test]
+    fn test_infer_upstage() {
+        assert_eq!(infer_provider_for_model("solar-pro3"), Some("upstage"));
+        assert_eq!(infer_provider_for_model("solar-pro2"), Some("upstage"));
+        assert_eq!(infer_provider_for_model("solar-mini"), Some("upstage"));
     }
 
     #[test]

--- a/openplanter-desktop/crates/op-core/src/config.rs
+++ b/openplanter-desktop/crates/op-core/src/config.rs
@@ -13,6 +13,7 @@ pub static PROVIDER_DEFAULT_MODELS: LazyLock<HashMap<&'static str, &'static str>
             ("anthropic", "claude-opus-4-6"),
             ("openrouter", "anthropic/claude-sonnet-4-5"),
             ("cerebras", "qwen-3-235b-a22b-instruct-2507"),
+            ("upstage", "solar-pro3"),
             ("ollama", "llama3.2"),
         ])
     });
@@ -55,6 +56,7 @@ pub struct AgentConfig {
     pub anthropic_base_url: String,
     pub openrouter_base_url: String,
     pub cerebras_base_url: String,
+    pub upstage_base_url: String,
     pub ollama_base_url: String,
     pub exa_base_url: String,
 
@@ -64,6 +66,7 @@ pub struct AgentConfig {
     pub anthropic_api_key: Option<String>,
     pub openrouter_api_key: Option<String>,
     pub cerebras_api_key: Option<String>,
+    pub upstage_api_key: Option<String>,
     pub exa_api_key: Option<String>,
     pub voyage_api_key: Option<String>,
 
@@ -100,6 +103,7 @@ impl Default for AgentConfig {
             anthropic_base_url: "https://api.anthropic.com/v1".into(),
             openrouter_base_url: "https://openrouter.ai/api/v1".into(),
             cerebras_base_url: "https://api.cerebras.ai/v1".into(),
+            upstage_base_url: "https://api.upstage.ai/v1".into(),
             ollama_base_url: "http://localhost:11434/v1".into(),
             exa_base_url: "https://api.exa.ai".into(),
             api_key: None,
@@ -107,6 +111,7 @@ impl Default for AgentConfig {
             anthropic_api_key: None,
             openrouter_api_key: None,
             cerebras_api_key: None,
+            upstage_api_key: None,
             exa_api_key: None,
             voyage_api_key: None,
             max_depth: 4,
@@ -147,6 +152,9 @@ impl AgentConfig {
 
         let cerebras_api_key = env_opt("OPENPLANTER_CEREBRAS_API_KEY")
             .or_else(|| env_opt("CEREBRAS_API_KEY"));
+
+        let upstage_api_key = env_opt("OPENPLANTER_UPSTAGE_API_KEY")
+            .or_else(|| env_opt("UPSTAGE_API_KEY"));
 
         let exa_api_key = env_opt("OPENPLANTER_EXA_API_KEY")
             .or_else(|| env_opt("EXA_API_KEY"));
@@ -196,6 +204,10 @@ impl AgentConfig {
                 "OPENPLANTER_CEREBRAS_BASE_URL",
                 "https://api.cerebras.ai/v1",
             ),
+            upstage_base_url: env_or(
+                "OPENPLANTER_UPSTAGE_BASE_URL",
+                "https://api.upstage.ai/v1",
+            ),
             ollama_base_url: env_or(
                 "OPENPLANTER_OLLAMA_BASE_URL",
                 "http://localhost:11434/v1",
@@ -205,6 +217,7 @@ impl AgentConfig {
             anthropic_api_key,
             openrouter_api_key,
             cerebras_api_key,
+            upstage_api_key,
             exa_api_key,
             voyage_api_key,
             max_depth: env_int("OPENPLANTER_MAX_DEPTH", 4),
@@ -283,6 +296,7 @@ mod tests {
             PROVIDER_DEFAULT_MODELS.get("cerebras"),
             Some(&"qwen-3-235b-a22b-instruct-2507")
         );
+        assert_eq!(PROVIDER_DEFAULT_MODELS.get("upstage"), Some(&"solar-pro3"));
         assert_eq!(PROVIDER_DEFAULT_MODELS.get("ollama"), Some(&"llama3.2"));
     }
 

--- a/openplanter-desktop/crates/op-core/src/credentials.rs
+++ b/openplanter-desktop/crates/op-core/src/credentials.rs
@@ -16,6 +16,7 @@ pub struct CredentialBundle {
     pub anthropic_api_key: Option<String>,
     pub openrouter_api_key: Option<String>,
     pub cerebras_api_key: Option<String>,
+    pub upstage_api_key: Option<String>,
     pub exa_api_key: Option<String>,
     pub voyage_api_key: Option<String>,
 }
@@ -23,11 +24,12 @@ pub struct CredentialBundle {
 impl CredentialBundle {
     /// Returns `true` if any key has a non-empty value.
     pub fn has_any(&self) -> bool {
-        let keys: [&Option<String>; 6] = [
+        let keys: [&Option<String>; 7] = [
             &self.openai_api_key,
             &self.anthropic_api_key,
             &self.openrouter_api_key,
             &self.cerebras_api_key,
+            &self.upstage_api_key,
             &self.exa_api_key,
             &self.voyage_api_key,
         ];
@@ -51,6 +53,7 @@ impl CredentialBundle {
         fill!(anthropic_api_key);
         fill!(openrouter_api_key);
         fill!(cerebras_api_key);
+        fill!(upstage_api_key);
         fill!(exa_api_key);
         fill!(voyage_api_key);
     }
@@ -69,6 +72,7 @@ impl CredentialBundle {
         add!(anthropic_api_key, "anthropic_api_key");
         add!(openrouter_api_key, "openrouter_api_key");
         add!(cerebras_api_key, "cerebras_api_key");
+        add!(upstage_api_key, "upstage_api_key");
         add!(exa_api_key, "exa_api_key");
         add!(voyage_api_key, "voyage_api_key");
         out
@@ -87,6 +91,7 @@ impl CredentialBundle {
             anthropic_api_key: get_str(payload, "anthropic_api_key"),
             openrouter_api_key: get_str(payload, "openrouter_api_key"),
             cerebras_api_key: get_str(payload, "cerebras_api_key"),
+            upstage_api_key: get_str(payload, "upstage_api_key"),
             exa_api_key: get_str(payload, "exa_api_key"),
             voyage_api_key: get_str(payload, "voyage_api_key"),
         }
@@ -151,6 +156,11 @@ pub fn parse_env_file(path: &Path) -> CredentialBundle {
             "CEREBRAS_API_KEY",
             "OPENPLANTER_CEREBRAS_API_KEY",
         ),
+        upstage_api_key: get_key(
+            &env_map,
+            "UPSTAGE_API_KEY",
+            "OPENPLANTER_UPSTAGE_API_KEY",
+        ),
         exa_api_key: get_key(&env_map, "EXA_API_KEY", "OPENPLANTER_EXA_API_KEY"),
         voyage_api_key: get_key(&env_map, "VOYAGE_API_KEY", "OPENPLANTER_VOYAGE_API_KEY"),
     }
@@ -171,6 +181,7 @@ pub fn credentials_from_env() -> CredentialBundle {
         anthropic_api_key: env_key("OPENPLANTER_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"),
         openrouter_api_key: env_key("OPENPLANTER_OPENROUTER_API_KEY", "OPENROUTER_API_KEY"),
         cerebras_api_key: env_key("OPENPLANTER_CEREBRAS_API_KEY", "CEREBRAS_API_KEY"),
+        upstage_api_key: env_key("OPENPLANTER_UPSTAGE_API_KEY", "UPSTAGE_API_KEY"),
         exa_api_key: env_key("OPENPLANTER_EXA_API_KEY", "EXA_API_KEY"),
         voyage_api_key: env_key("OPENPLANTER_VOYAGE_API_KEY", "VOYAGE_API_KEY"),
     }

--- a/openplanter-desktop/crates/op-core/src/model/openai.rs
+++ b/openplanter-desktop/crates/op-core/src/model/openai.rs
@@ -1,6 +1,6 @@
 // OpenAI-compatible model implementation.
 //
-// Handles openai, openrouter, cerebras, and ollama — all use /chat/completions.
+// Handles openai, openrouter, cerebras, upstage, and ollama — all use /chat/completions.
 
 use std::collections::HashMap;
 

--- a/openplanter-desktop/crates/op-core/src/settings.rs
+++ b/openplanter-desktop/crates/op-core/src/settings.rs
@@ -38,6 +38,7 @@ pub struct PersistentSettings {
     pub default_model_anthropic: Option<String>,
     pub default_model_openrouter: Option<String>,
     pub default_model_cerebras: Option<String>,
+    pub default_model_upstage: Option<String>,
     pub default_model_ollama: Option<String>,
 }
 
@@ -49,6 +50,7 @@ impl PersistentSettings {
             "anthropic" => self.default_model_anthropic.as_deref(),
             "openrouter" => self.default_model_openrouter.as_deref(),
             "cerebras" => self.default_model_cerebras.as_deref(),
+            "upstage" => self.default_model_upstage.as_deref(),
             "ollama" => self.default_model_ollama.as_deref(),
             _ => None,
         };
@@ -84,6 +86,7 @@ impl PersistentSettings {
             default_model_anthropic: trim_opt(&self.default_model_anthropic),
             default_model_openrouter: trim_opt(&self.default_model_openrouter),
             default_model_cerebras: trim_opt(&self.default_model_cerebras),
+            default_model_upstage: trim_opt(&self.default_model_upstage),
             default_model_ollama: trim_opt(&self.default_model_ollama),
         })
     }
@@ -104,6 +107,7 @@ impl PersistentSettings {
         add!(default_model_anthropic, "default_model_anthropic");
         add!(default_model_openrouter, "default_model_openrouter");
         add!(default_model_cerebras, "default_model_cerebras");
+        add!(default_model_upstage, "default_model_upstage");
         add!(default_model_ollama, "default_model_ollama");
         payload
     }
@@ -129,6 +133,7 @@ impl PersistentSettings {
             default_model_anthropic: get_str(obj, "default_model_anthropic"),
             default_model_openrouter: get_str(obj, "default_model_openrouter"),
             default_model_cerebras: get_str(obj, "default_model_cerebras"),
+            default_model_upstage: get_str(obj, "default_model_upstage"),
             default_model_ollama: get_str(obj, "default_model_ollama"),
         };
         settings.normalized()

--- a/openplanter-desktop/crates/op-core/src/tools/defs.rs
+++ b/openplanter-desktop/crates/op-core/src/tools/defs.rs
@@ -365,24 +365,30 @@ fn strict_fixup(schema: &mut Value) {
     }
 }
 
-/// Convert to OpenAI tools format: `[{ type: "function", function: { name, description, parameters, strict } }]`
-pub fn to_openai_tools() -> Vec<Value> {
-    mvp_tool_defs()
-        .into_iter()
+fn openai_tools_from(defs: Vec<ToolDef>, strict: bool) -> Vec<Value> {
+    defs.into_iter()
         .map(|def| {
             let mut params = def.parameters;
-            strict_fixup(&mut params);
+            let mut function = json!({
+                "name": def.name,
+                "description": def.description,
+            });
+            if strict {
+                strict_fixup(&mut params);
+                function["strict"] = json!(true);
+            }
+            function["parameters"] = params;
             json!({
                 "type": "function",
-                "function": {
-                    "name": def.name,
-                    "description": def.description,
-                    "parameters": params,
-                    "strict": true
-                }
+                "function": function
             })
         })
         .collect()
+}
+
+/// Convert to OpenAI tools format: `[{ type: "function", function: { name, description, parameters, strict } }]`
+pub fn to_openai_tools() -> Vec<Value> {
+    openai_tools_from(mvp_tool_defs(), true)
 }
 
 /// Convert to Anthropic tools format: `[{ name, description, input_schema }]`
@@ -403,6 +409,7 @@ pub fn to_anthropic_tools() -> Vec<Value> {
 pub fn build_tool_defs(provider: &str) -> Vec<Value> {
     match provider {
         "anthropic" => to_anthropic_tools(),
+        "upstage" => openai_tools_from(mvp_tool_defs(), false),
         _ => to_openai_tools(),
     }
 }
@@ -434,22 +441,7 @@ pub fn build_curator_tool_defs(provider: &str) -> Vec<Value> {
                 })
             })
             .collect(),
-        _ => filtered
-            .into_iter()
-            .map(|def| {
-                let mut params = def.parameters;
-                strict_fixup(&mut params);
-                json!({
-                    "type": "function",
-                    "function": {
-                        "name": def.name,
-                        "description": def.description,
-                        "parameters": params,
-                        "strict": true
-                    }
-                })
-            })
-            .collect(),
+        _ => openai_tools_from(filtered, provider != "upstage"),
     }
 }
 
@@ -518,6 +510,16 @@ mod tests {
     fn test_build_tool_defs_openai() {
         let tools = build_tool_defs("openai");
         assert_eq!(tools[0]["type"], "function");
+    }
+
+    #[test]
+    fn test_build_tool_defs_upstage_no_strict() {
+        // Upstage rejects function.strict=true with HTTP 400
+        let tools = build_tool_defs("upstage");
+        assert_eq!(tools[0]["type"], "function");
+        assert!(tools[0]["function"].get("strict").is_none());
+        let curator = build_curator_tool_defs("upstage");
+        assert!(curator[0]["function"].get("strict").is_none());
     }
 
     #[test]

--- a/openplanter-desktop/crates/op-tauri/src/commands/config.rs
+++ b/openplanter-desktop/crates/op-tauri/src/commands/config.rs
@@ -84,6 +84,11 @@ fn known_models_for_provider(provider: &str) -> Vec<ModelInfo> {
             ("qwen-3-235b-a22b-instruct-2507", "Qwen-3 235B"),
             ("llama-4-scout-17b-16e-instruct", "Llama-4 Scout"),
         ],
+        "upstage" => vec![
+            ("solar-pro3", "Solar Pro 3"),
+            ("solar-pro2", "Solar Pro 2"),
+            ("solar-mini", "Solar Mini"),
+        ],
         "ollama" => vec![
             ("llama3.2", "Llama 3.2"),
             ("mistral", "Mistral"),
@@ -113,7 +118,7 @@ pub async fn list_models(
 ) -> Result<Vec<ModelInfo>, String> {
     if provider == "all" {
         let mut all = Vec::new();
-        for p in &["openai", "anthropic", "openrouter", "cerebras", "ollama"] {
+        for p in &["openai", "anthropic", "openrouter", "cerebras", "upstage", "ollama"] {
             all.extend(known_models_for_provider(p));
         }
         Ok(all)
@@ -140,6 +145,7 @@ pub fn build_credential_status(cfg: &op_core::config::AgentConfig) -> HashMap<St
     status.insert("anthropic".to_string(), cfg.anthropic_api_key.is_some());
     status.insert("openrouter".to_string(), cfg.openrouter_api_key.is_some());
     status.insert("cerebras".to_string(), cfg.cerebras_api_key.is_some());
+    status.insert("upstage".to_string(), cfg.upstage_api_key.is_some());
     status.insert("ollama".to_string(), true); // Ollama never needs a key
     status.insert("exa".to_string(), cfg.exa_api_key.is_some());
     status
@@ -169,6 +175,10 @@ pub async fn get_credentials_status(
     status.insert(
         "cerebras".to_string(),
         cfg.cerebras_api_key.is_some() || env_creds.cerebras_api_key.is_some(),
+    );
+    status.insert(
+        "upstage".to_string(),
+        cfg.upstage_api_key.is_some() || env_creds.upstage_api_key.is_some(),
     );
     status.insert("ollama".to_string(), true); // Ollama never needs a key
     status.insert(
@@ -210,6 +220,12 @@ mod tests {
     }
 
     #[test]
+    fn test_upstage_models_nonempty() {
+        let models = known_models_for_provider("upstage");
+        assert!(!models.is_empty(), "upstage should have known models");
+    }
+
+    #[test]
     fn test_ollama_models_nonempty() {
         let models = known_models_for_provider("ollama");
         assert!(!models.is_empty(), "ollama should have known models");
@@ -224,7 +240,7 @@ mod tests {
     #[test]
     fn test_all_providers_model_ids_unique() {
         let mut all_ids = HashSet::new();
-        for p in &["openai", "anthropic", "openrouter", "cerebras", "ollama"] {
+        for p in &["openai", "anthropic", "openrouter", "cerebras", "upstage", "ollama"] {
             for m in known_models_for_provider(p) {
                 assert!(
                     all_ids.insert(m.id.clone()),
@@ -237,7 +253,7 @@ mod tests {
 
     #[test]
     fn test_model_info_fields() {
-        for provider in &["openai", "anthropic", "openrouter", "cerebras", "ollama"] {
+        for provider in &["openai", "anthropic", "openrouter", "cerebras", "upstage", "ollama"] {
             for m in known_models_for_provider(provider) {
                 assert!(!m.id.is_empty(), "model id should not be empty");
                 assert!(m.name.is_some(), "model name should be Some for {}", m.id);
@@ -257,11 +273,13 @@ mod tests {
         cfg.anthropic_api_key = None;
         cfg.openrouter_api_key = None;
         cfg.cerebras_api_key = None;
+        cfg.upstage_api_key = None;
         let status = build_credential_status(&cfg);
         assert_eq!(status["openai"], false);
         assert_eq!(status["anthropic"], false);
         assert_eq!(status["openrouter"], false);
         assert_eq!(status["cerebras"], false);
+        assert_eq!(status["upstage"], false);
         assert_eq!(status["ollama"], true, "ollama always true");
     }
 
@@ -272,6 +290,7 @@ mod tests {
         cfg.anthropic_api_key = None;
         cfg.openrouter_api_key = None;
         cfg.cerebras_api_key = None;
+        cfg.upstage_api_key = None;
         let status = build_credential_status(&cfg);
         assert_eq!(status["openai"], true);
         assert_eq!(status["anthropic"], false);
@@ -284,6 +303,7 @@ mod tests {
         cfg.anthropic_api_key = Some("sk-ant-test".to_string());
         cfg.openrouter_api_key = None;
         cfg.cerebras_api_key = None;
+        cfg.upstage_api_key = None;
         let status = build_credential_status(&cfg);
         assert_eq!(status["anthropic"], true);
         assert_eq!(status["openai"], false);
@@ -296,6 +316,7 @@ mod tests {
         cfg.anthropic_api_key = None;
         cfg.openrouter_api_key = None;
         cfg.cerebras_api_key = None;
+        cfg.upstage_api_key = None;
         let status = build_credential_status(&cfg);
         assert_eq!(status["ollama"], true);
     }
@@ -307,6 +328,7 @@ mod tests {
         cfg.anthropic_api_key = Some("k2".to_string());
         cfg.openrouter_api_key = Some("k3".to_string());
         cfg.cerebras_api_key = Some("k4".to_string());
+        cfg.upstage_api_key = Some("k6".to_string());
         cfg.exa_api_key = Some("k5".to_string());
         let status = build_credential_status(&cfg);
         for (provider, has_key) in &status {
@@ -315,9 +337,9 @@ mod tests {
     }
 
     #[test]
-    fn test_cred_status_has_six_entries() {
+    fn test_cred_status_has_seven_entries() {
         let cfg = op_core::config::AgentConfig::from_env("/nonexistent");
         let status = build_credential_status(&cfg);
-        assert_eq!(status.len(), 6, "should have 6 entries (5 providers + exa)");
+        assert_eq!(status.len(), 7, "should have 7 entries (6 providers + exa)");
     }
 }

--- a/openplanter-desktop/crates/op-tauri/src/state.rs
+++ b/openplanter-desktop/crates/op-tauri/src/state.rs
@@ -23,6 +23,7 @@ pub fn merge_credentials_into_config(
     merge!(anthropic_api_key);
     merge!(openrouter_api_key);
     merge!(cerebras_api_key);
+    merge!(upstage_api_key);
     merge!(exa_api_key);
     merge!(voyage_api_key);
 }
@@ -70,6 +71,7 @@ mod tests {
         cfg.anthropic_api_key = None;
         cfg.openrouter_api_key = None;
         cfg.cerebras_api_key = None;
+        cfg.upstage_api_key = None;
         cfg.exa_api_key = None;
         cfg.voyage_api_key = None;
         cfg

--- a/openplanter-desktop/crates/op-tauri/src/state.rs
+++ b/openplanter-desktop/crates/op-tauri/src/state.rs
@@ -35,9 +35,21 @@ pub struct AppState {
     pub cancel_token: Arc<Mutex<CancellationToken>>,
 }
 
+/// Default workspace for the desktop app.
+///
+/// GUI apps launch with cwd = `/`, so `from_env(".")` would resolve the
+/// workspace to the (read-only) filesystem root. Default to a writable
+/// per-user directory instead; OPENPLANTER_WORKSPACE overrides it.
+fn default_workspace() -> String {
+    std::env::var("OPENPLANTER_WORKSPACE")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "~/OpenPlanter".to_string())
+}
+
 impl AppState {
     pub fn new() -> Self {
-        let mut cfg = AgentConfig::from_env(".");
+        let mut cfg = AgentConfig::from_env(default_workspace());
 
         // Load .env files and merge credentials into config
         let env_creds = credentials_from_env();

--- a/openplanter-desktop/frontend/e2e/fixtures/graph-data.ts
+++ b/openplanter-desktop/frontend/e2e/fixtures/graph-data.ts
@@ -72,6 +72,7 @@ export const MOCK_CREDENTIALS = {
   anthropic: true,
   openrouter: false,
   cerebras: false,
+  upstage: false,
   ollama: true,
   exa: false,
 };

--- a/openplanter-desktop/frontend/src/api/invoke.test.ts
+++ b/openplanter-desktop/frontend/src/api/invoke.test.ts
@@ -102,6 +102,7 @@ describe("invoke wrappers", () => {
       anthropic: true,
       openrouter: false,
       cerebras: false,
+      upstage: false,
       ollama: true,
       exa: false,
     }));

--- a/openplanter-desktop/frontend/src/api/types.ts
+++ b/openplanter-desktop/frontend/src/api/types.ts
@@ -99,6 +99,7 @@ export interface PersistentSettings {
   default_model_anthropic?: string | null;
   default_model_openrouter?: string | null;
   default_model_cerebras?: string | null;
+  default_model_upstage?: string | null;
   default_model_ollama?: string | null;
 }
 

--- a/openplanter-desktop/frontend/src/commands/completionRegistry.ts
+++ b/openplanter-desktop/frontend/src/commands/completionRegistry.ts
@@ -13,6 +13,7 @@ const PROVIDER_FILTERS: CompletionItem[] = [
   { value: "anthropic", description: "Anthropic models" },
   { value: "ollama", description: "Local Ollama models" },
   { value: "cerebras", description: "Cerebras models" },
+  { value: "upstage", description: "Upstage models" },
   { value: "openrouter", description: "OpenRouter models" },
 ];
 

--- a/openplanter-desktop/frontend/src/commands/model.test.ts
+++ b/openplanter-desktop/frontend/src/commands/model.test.ts
@@ -34,6 +34,12 @@ describe("inferProvider", () => {
     expect(inferProvider("qwen-3-235b-a22b-instruct-2507")).toBe("cerebras");
   });
 
+  it("solar returns upstage", () => {
+    expect(inferProvider("solar-pro3")).toBe("upstage");
+    expect(inferProvider("solar-pro2")).toBe("upstage");
+    expect(inferProvider("solar-mini")).toBe("upstage");
+  });
+
   it("qwen without 3 returns ollama", () => {
     expect(inferProvider("qwen2")).toBe("ollama");
   });

--- a/openplanter-desktop/frontend/src/commands/model.ts
+++ b/openplanter-desktop/frontend/src/commands/model.ts
@@ -24,6 +24,8 @@ export const MODEL_ALIASES: Record<string, string> = {
   deepseek: "deepseek",
   qwen: "qwen-3-235b-a22b-instruct-2507",
   "qwen-3": "qwen-3-235b-a22b-instruct-2507",
+  solar: "solar-pro3",
+  upstage: "solar-pro3",
 };
 
 /** Infer provider from a model name, matching builder.rs patterns. */
@@ -31,6 +33,7 @@ export function inferProvider(model: string): string | null {
   if (model.includes("/")) return "openrouter";
   if (/^claude/i.test(model)) return "anthropic";
   if (/^(llama.*cerebras|qwen-3|gpt-oss|zai-glm)/i.test(model)) return "cerebras";
+  if (/^solar/i.test(model)) return "upstage";
   if (/^(gpt|o[1-4]-|o[1-4]$|chatgpt|dall-e|tts-|whisper)/i.test(model)) return "openai";
   if (/^(llama|mistral|gemma|phi|codellama|deepseek|vicuna|tinyllama|neural-chat|dolphin|wizardlm|orca|nous-hermes|command-r|qwen)/i.test(model)) return "ollama";
   return null;

--- a/openplanter-desktop/frontend/src/components/App.test.ts
+++ b/openplanter-desktop/frontend/src/components/App.test.ts
@@ -48,7 +48,7 @@ describe("createApp", () => {
     __setHandler("list_sessions", () => [SESSION_B, SESSION_A]);
     __setHandler("get_credentials_status", () => ({
       openai: true, anthropic: true, openrouter: false,
-      cerebras: false, ollama: true, exa: false,
+      cerebras: false, upstage: false, ollama: true, exa: false,
     }));
     __setHandler("open_session", () => ({
       id: "20260227-120000-cccc3333",
@@ -95,9 +95,11 @@ describe("createApp", () => {
 
     await vi.waitFor(() => {
       const creds = root.querySelector(".cred-status");
-      expect(creds!.children.length).toBe(6);
+      expect(creds!.children.length).toBe(7);
       expect(creds!.querySelector(".cred-ok")!.textContent).toContain("openai");
       expect(creds!.querySelector(".cred-missing")!.textContent).toContain("openrouter");
+      const missing = Array.from(creds!.querySelectorAll(".cred-missing")).map((el) => el.textContent);
+      expect(missing.some((t) => t!.includes("upstage"))).toBe(true);
     });
   });
 

--- a/openplanter-desktop/frontend/src/components/App.ts
+++ b/openplanter-desktop/frontend/src/components/App.ts
@@ -300,7 +300,7 @@ async function loadCredentials(container: HTMLElement): Promise<void> {
   try {
     const status = await getCredentialsStatus();
     container.innerHTML = "";
-    const providers = ["openai", "anthropic", "openrouter", "cerebras", "ollama", "exa"];
+    const providers = ["openai", "anthropic", "openrouter", "cerebras", "upstage", "ollama", "exa"];
     for (const p of providers) {
       const row = document.createElement("div");
       const hasKey = status[p] ?? false;

--- a/openplanter-desktop/frontend/src/components/InputBar.ts
+++ b/openplanter-desktop/frontend/src/components/InputBar.ts
@@ -117,7 +117,20 @@ export function createInputBar(): HTMLElement {
         appState.update((s) => ({ ...s, sessionId: session.id }));
         window.dispatchEvent(new CustomEvent("session-changed", { detail: { isNew: true } }));
       } catch (e) {
-        console.error("Failed to create session:", e);
+        appState.update((s) => ({
+          ...s,
+          isRunning: false,
+          messages: [
+            ...s.messages,
+            {
+              id: crypto.randomUUID(),
+              role: "system" as const,
+              content: `Failed to create session: ${e}`,
+              timestamp: Date.now(),
+            },
+          ],
+        }));
+        return;
       }
     }
 


### PR DESCRIPTION
Desktop-side follow-up to #36: brings the same Upstage provider to the Tauri app.

- op-core: `upstage_api_key` / `upstage_base_url` in config, credentials, and settings; provider inference for `solar*` model names; default model `solar-pro3`
- Sidebar credential status now lists Upstage, and the model picker offers solar-pro3 / solar-pro2 / solar-mini
- Tested live against `solar-open2`

Two fixes are included because the app doesn't actually work with Upstage (or at all, when launched from Finder) without them:

1. **Tool schemas without `strict`** — Upstage's chat endpoint rejects `function.strict: true` with HTTP 400, so tool defs for the upstage provider are built without the flag (same treatment as the CLI in #36).
2. **Writable default workspace** — GUI apps launch with cwd=`/`, so the workspace resolved to the read-only filesystem root, session creation failed silently, and the frontend then called `solve` with a null sessionId. The default workspace is now `~/OpenPlanter` (overridable via `OPENPLANTER_WORKSPACE`), and session-creation failures are shown in the chat instead of proceeding with a null session.

`cargo test -p op-core -p op-tauri` → 287 passed. Frontend `vitest` → 201 passed, `tsc` clean. Built and ran the .app locally with a real investigation session.
